### PR TITLE
更新 Istio 中文官网链接

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -50,7 +50,7 @@ paginate = 10
 [[menu.main]]
     parent="docs"
     name="Istio中文官网"
-    url = "https://istio.io/zh/"
+    url = "https://archive.istio.io/v1.2/zh"
     weight = 3
 
 [[menu.main]]


### PR DESCRIPTION
- 因为 Istio 中文官网的 master 分支已经落后官网有近六个月之久，现在
istio.io/zh 网页也下线，只能暂时替换为 v1.2 的历史版本。
